### PR TITLE
fix remaining arguments to support more than one

### DIFF
--- a/_ok.ps1
+++ b/_ok.ps1
@@ -1,13 +1,11 @@
 # with no parameter: looks in the current folder for a ".ok" file, and lists its commands numbered
 # with a number parameter, runs the relevant command from the .ok file, e.g. "ok 1" runs first line of ".ok" file
-function ok([parameter(mandatory=$false, position=0)]$number,
-    [parameter(mandatory=$false, position=1, ValueFromRemainingArguments=$true)]$arg
-) {
+function ok([parameter(mandatory=$false, position=0)]$number) {
 
   # this is a private function used by ok
   # given a filename (a file full of commands) and a number (possibly null) and some remaining parameters: 
   #   invoke the numbered command (if a number was given) or display a numbered list of the commands
-  function ok_file($file, $number, $arg) {
+  function ok_file($file, $number) {
     $commands = @{};
     $num = 0;
     cat $file | % {
@@ -52,7 +50,7 @@ function ok([parameter(mandatory=$false, position=0)]$number,
     }
   }
   
-  if (test-path ".\.ok") { ok_file ".\.ok" $number $arg}
+  if (test-path ".\.ok") { ok_file ".\.ok" $number @args }
 }
 
 
@@ -62,8 +60,8 @@ if (test-path alias:cd) {
 }
 
 # We create our `cd` function as a wrapper around set-location that calls 'ok'
-function cd ([parameter(ValueFromRemainingArguments = $true)][string]$Passthrough) {
-  Set-Location $Passthrough
+function cd () {
+  Set-Location @args
   ok # Call 'ok'
 }
 


### PR DESCRIPTION
ValueFromRemainingArguments only works for functions that specify [CmdletBinding], but here all we want is a true pass-through of the remaining args, and PowerShell has a built-in way to do exactly that... see "Get-Help about_Automatic_Variables" or https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables

also, ok_file doesn't use the remaining parameters that are passed in via the call on line 53, but that call is also cleaned up such that inside ok_file $args would be an object[] containing those params if they exist, and $null if no such params are passed